### PR TITLE
add new command-line parameter exclude-analyse

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -61,6 +61,7 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				new InputOption('fix', null, InputOption::VALUE_NONE, 'Launch PHPStan Pro'),
 				new InputOption('watch', null, InputOption::VALUE_NONE, 'Launch PHPStan Pro'),
 				new InputOption('pro', null, InputOption::VALUE_NONE, 'Launch PHPStan Pro'),
+				new InputOption('analyse-excludes', 'e', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude paths from analysis'),
 			]);
 	}
 
@@ -94,6 +95,7 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		$pathsFile = $input->getOption('paths-file');
 		$allowXdebug = $input->getOption('xdebug');
 		$debugEnabled = (bool) $input->getOption('debug');
+		$analyseExcludes = $input->getOption('analyse-excludes');
 		$fix = (bool) $input->getOption('fix') || (bool) $input->getOption('watch') || (bool) $input->getOption('pro');
 
 		/** @var string|false|null $generateBaselineFile */
@@ -111,7 +113,8 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 			|| (!is_string($configuration) && $configuration !== null)
 			|| (!is_string($level) && $level !== null)
 			|| (!is_string($pathsFile) && $pathsFile !== null)
-			|| (!is_bool($allowXdebug))
+			|| (!is_bool($allowXdebug)
+			|| !is_array($analyseExcludes))
 		) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
@@ -130,7 +133,9 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				$level,
 				$allowXdebug,
 				true,
-				$debugEnabled
+				$debugEnabled,
+				null,
+				$analyseExcludes
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/Command/ClearResultCacheCommand.php
+++ b/src/Command/ClearResultCacheCommand.php
@@ -62,7 +62,10 @@ class ClearResultCacheCommand extends Command
 				null,
 				'0',
 				false,
-				false
+				false,
+				false,
+				null,
+				[]
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/Command/DumpDependenciesCommand.php
+++ b/src/Command/DumpDependenciesCommand.php
@@ -78,7 +78,10 @@ class DumpDependenciesCommand extends \Symfony\Component\Console\Command\Command
 				null,
 				'0', // irrelevant but prevents an error when a config file is passed
 				$allowXdebug,
-				true
+				true,
+				false,
+				null,
+				[]
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -117,7 +117,8 @@ class FixerWorkerCommand extends Command
 				$allowXdebug,
 				false,
 				false,
-				$singleReflectionFile
+				$singleReflectionFile,
+				[]
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -54,6 +54,7 @@ class WorkerCommand extends Command
 				new InputOption('identifier', null, InputOption::VALUE_REQUIRED),
 				new InputOption('tmp-file', null, InputOption::VALUE_REQUIRED),
 				new InputOption('instead-of', null, InputOption::VALUE_REQUIRED),
+				new InputOption('analyse-excludes', 'e', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude paths from analysis'),
 			]);
 	}
 
@@ -68,7 +69,7 @@ class WorkerCommand extends Command
 		$allowXdebug = $input->getOption('xdebug');
 		$port = $input->getOption('port');
 		$identifier = $input->getOption('identifier');
-
+		$analyseExcludes = $input->getOption('analyse-excludes');
 		if (
 			!is_array($paths)
 			|| (!is_string($memoryLimit) && $memoryLimit !== null)
@@ -79,6 +80,7 @@ class WorkerCommand extends Command
 			|| (!is_bool($allowXdebug))
 			|| !is_string($port)
 			|| !is_string($identifier)
+			|| !is_array($analyseExcludes)
 		) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
@@ -109,7 +111,8 @@ class WorkerCommand extends Command
 				$allowXdebug,
 				false,
 				false,
-				$singleReflectionFile
+				$singleReflectionFile,
+				$analyseExcludes
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -50,6 +50,7 @@ class ContainerFactory
 	 * @param string|null $generateBaselineFile
 	 * @param string|null $cliAutoloadFile
 	 * @param string|null $singleReflectionFile
+	 * @param string[]|null $analyseExcludes
 	 * @return \PHPStan\DependencyInjection\Container
 	 */
 	public function create(
@@ -62,7 +63,8 @@ class ContainerFactory
 		string $usedLevel = CommandHelper::DEFAULT_LEVEL,
 		?string $generateBaselineFile = null,
 		?string $cliAutoloadFile = null,
-		?string $singleReflectionFile = null
+		?string $singleReflectionFile = null,
+		?array $analyseExcludes = []
 	): Container
 	{
 		$configurator = new Configurator(new LoaderFactory(
@@ -90,6 +92,7 @@ class ContainerFactory
 			'usedLevel' => $usedLevel,
 			'cliAutoloadFile' => $cliAutoloadFile,
 			'fixerTmpDir' => sys_get_temp_dir() . '/phpstan-fixer',
+			'excludes_analyse' => $analyseExcludes,
 		]);
 		$configurator->addDynamicParameters([
 			'singleReflectionFile' => $singleReflectionFile,

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -52,6 +52,13 @@ class AnalyseCommandTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('magic value', SOME_CONSTANT_IN_AUTOLOAD_FILE);
 	}
 
+	public function testExcludeAnalyseParameter(): void
+	{
+		$output = $this->runCommand(0, ['-e' => ['test']]);
+		$this->assertStringNotContainsString('test/', $output);
+	}
+
+
 	/**
 	 * @return string[][]
 	 */

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -125,7 +125,10 @@ class CommandHelperTest extends TestCase
 				null,
 				$level,
 				false,
-				true
+				true,
+				false,
+				null,
+				['vendor']
 			);
 			if ($expectException) {
 				$this->fail();
@@ -250,7 +253,10 @@ class CommandHelperTest extends TestCase
 			null,
 			'0',
 			false,
-			true
+			true,
+			false,
+			null,
+			[]
 		);
 		$parameters = $result->getContainer()->getParameters();
 		foreach ($expectedParameters as $name => $expectedValue) {


### PR DESCRIPTION
Add new paramater for commandline to exclude paths on analyse-command, implementation using the existing config parameter exclude_anaylse funktionality.